### PR TITLE
Fix const correctness on C bindings

### DIFF
--- a/cemitter.h
+++ b/cemitter.h
@@ -2,9 +2,13 @@
 #ifndef _GLPK_EVENTEMITTER_CEMITER_H
 #define _GLPK_EVENTEMITTER_CEMITER_H
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 typedef void (*eventemitter_fn)(const char*, const char*);
-typedef void (*eventemitter_fn_r)(void* sender, const char*, const char*);
+typedef void (*eventemitter_fn_r)(const void* sender, const char*, const char*);
+#ifdef __cplusplus
 };
+#endif
 
 #endif

--- a/eventemitter.hpp
+++ b/eventemitter.hpp
@@ -407,11 +407,11 @@ class AsyncEventEmittingReentrantCWorker : public AsyncQueuedProgressWorker<Prog
         ExecuteWithEmitter(&sender, this->reentrant_emit);
     }
 
-    static void reentrant_emit(void* sender, const char* ev, const char* value) {
+    static void reentrant_emit(const void* sender, const char* ev, const char* value) {
         if (sender) {
             auto reports = new ProgressReport[1];
             reports[0] = {ev, value};
-            auto emitter = static_cast<ExecutionProgressSender*>(sender);
+            auto emitter = static_cast<const ExecutionProgressSender*>(sender);
             emitter->Send(reports, 1);
         }
     }


### PR DESCRIPTION
didn't mark the void* as const void*
also fixed the lack of _cplusplus guards around 'extern "C"'