### PR TITLE
Missed a header required for gcc

### DIFF
--- a/shared_ringbuffer.hpp
+++ b/shared_ringbuffer.hpp
@@ -3,6 +3,7 @@
 #define _GLPK_RINGBUFFER_H
 
 #include <algorithm>
+#include <condition_variable>
 #include <array>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
<condition_variable> header is necessary for gcc.