### PR TITLE
confirmed waitmorphing behavior, switching this

### DIFF
--- a/shared_ringbuffer.hpp
+++ b/shared_ringbuffer.hpp
@@ -39,8 +39,7 @@ class RingBuffer {
         buf_[write_idx_ % buf_.size()] = std::move(val);
         ++write_idx_;
 
-        // unlock before notify so we don't put the notified thread back to sleep immediately
-        guard.unlock();
+        // Notify under mutex to ensure consistent behavior; rely on wait-morphing for performance
         notifier_.notify_one();
         return true;
     }


### PR DESCRIPTION
This is more sane, and since waitmorphing behavior is provided by most
OS, there's no benefit to unlocking first