### PR TITLE
Fix up some docs and a TODO

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -638,7 +638,7 @@ FILE_PATTERNS          = *.cpp \
 # should be searched for input files as well. Possible values are YES and NO.
 # If left blank NO is used.
 
-RECURSIVE              = YES
+RECURSIVE              = NO
 
 # The EXCLUDE tag can be used to specify files and/or directories that should
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/shared_ringbuffer.hpp
+++ b/shared_ringbuffer.hpp
@@ -67,6 +67,7 @@ class RingBuffer {
         return unlocked_dequeue();
     }
 
+    /// @returns true if the ringbuffer is not full, false otherwise
     inline bool available() {
         std::unique_lock<std::mutex> guard{lock_};
         return unlocked_available();


### PR DESCRIPTION
Had a TODO to figure out the lifetime of the uv_async_t object; turns
out the entire lifetime is from ctor => destroy, so I can safely use a
smart pointer, and avoid at least one of the reeinterpret_cast<>s