### PR TITLE
add CRTP for full DTOR on delete in AsyncClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ Examples of using The EventEmitter, the first is the non-reentrant
 non-threadsafe version, the second is the threadsafe and reentrant, but
 requires you pass the emitter object around
 
+AsyncWorker uses 'self-destruction', and so the delete operation is deferred
+to run on the main thread via AsyncClose. This delete needs to cast a `void*`
+pointer to its proper type to delete it. At this point, it needs to know the
+sub-class to cast to; and so we see the CRTP to enable this.
+
 ```c++
 
-class TestWorker : public AsyncEventEmittingCWorker<1024> {
+class TestWorker : public AsyncEventEmittingCWorker<1024, TestWorker> {
  public:
     TestWorker(Nan::Callback* callback, std::shared_ptr<EventEmitter> emitter, size_t n)
         : AsyncEventEmittingCWorker(callback, emitter), n_(n) {}
@@ -39,7 +44,7 @@ class TestWorker : public AsyncEventEmittingCWorker<1024> {
     int32_t n_;
 };
 
-class TestReentrantWorker : public AsyncEventEmittingReentrantCWorker<1024> {
+class TestReentrantWorker : public AsyncEventEmittingReentrantCWorker<1024, TestReentrantWorker> {
  public:
     TestReentrantWorker(Nan::Callback* callback, std::shared_ptr<EventEmitter> emitter, size_t n)
         : AsyncEventEmittingReentrantCWorker(callback, emitter), n_(n) {}

--- a/async_event_emitting_reentrant_c_worker.hpp
+++ b/async_event_emitting_reentrant_c_worker.hpp
@@ -29,16 +29,16 @@ namespace NodeEvent {
 #define UNUSED(x) (void)(x)
 #endif
 
-template <size_t SIZE>
-class AsyncEventEmittingReentrantCWorker : public AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE> {
+template <size_t SIZE, class CRTP>
+class AsyncEventEmittingReentrantCWorker : public AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE, CRTP> {
  public:
-    typedef typename AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE>::ExecutionProgressSender ExecutionProgressSender;
+    typedef typename AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE, CRTP>::ExecutionProgressSender ExecutionProgressSender;
     /// @param[in] callback - the callback to invoke after Execute completes. (unless overridden, is called from
     ///                      HandleOKCallback with no arguments, and called from HandleErrorCallback with the errors
     ///                      reported (if any)
     /// @param[in] emitter - The emitter object to use for notifying JS callbacks for given events.
     AsyncEventEmittingReentrantCWorker(Nan::Callback* callback, std::shared_ptr<EventEmitter> emitter)
-        : AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE>(callback), emitter_(emitter) {}
+        : AsyncQueuedProgressWorker<EventEmitter::ProgressReport, SIZE, CRTP>(callback), emitter_(emitter) {}
 
     /// emit the EventEmitter::ProgressReport as an event via the given emitter, ignores whether or not the emit is successful
     ///

--- a/async_queued_progress_worker.hpp
+++ b/async_queued_progress_worker.hpp
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <iostream>
 
 #include <nan.h>
 #include <uv.h>
@@ -34,7 +35,8 @@ namespace NodeEvent {
 ///
 /// AsyncQueuedProgressWorker provides a ringbuffer (to avoid reallocations and poor locality of reference) to help
 /// prevent lost progress
-template <class T, size_t SIZE>
+/// Uses CRTP to ensure proper DTOR
+template <class T, size_t SIZE, class CRTP>
 class AsyncQueuedProgressWorker : public Nan::AsyncWorker {
  public:
     class ExecutionProgressSender {
@@ -125,14 +127,14 @@ class AsyncQueuedProgressWorker : public Nan::AsyncWorker {
     // This is invoked as an effect if calling uv_async_send(async_), so executes on the thread that the default
     // loop is running on, so it can safely touch v8 data structures
     static NAUV_WORK_CB(asyncNotifyProgressQueue) {
-        auto worker = static_cast<AsyncQueuedProgressWorker*>(async->data);
+        auto worker = static_cast<CRTP*>(async->data);
         worker->HandleProgressQueue();
     }
 
     // This is invoked after Destroy(), which executes on the thread that the default loop is running on, and so can
     // touch v8 data structures
     static void AsyncClose(uv_handle_t* handle) {
-        auto worker = static_cast<AsyncQueuedProgressWorker*>(handle->data);
+        auto worker = static_cast<CRTP*>(handle->data);
         // Destroy happens in the v8 main loop; so we can flush out the Progress queue here before destroying
         if (worker->buffer_.read_available()) {
             worker->HandleProgressQueue();

--- a/test/cpp/eventemitter.cpp
+++ b/test/cpp/eventemitter.cpp
@@ -10,7 +10,7 @@ using namespace NodeEvent;
 using namespace Nan;
 using namespace v8;
 
-class TestWorker : public AsyncEventEmittingCWorker<16> {
+class TestWorker : public AsyncEventEmittingCWorker<16, TestWorker> {
  public:
     TestWorker(Nan::Callback* callback, std::shared_ptr<EventEmitter> emitter, size_t n)
         : AsyncEventEmittingCWorker(callback, emitter), n_(n) {}
@@ -35,7 +35,7 @@ class TestWorker : public AsyncEventEmittingCWorker<16> {
     int32_t n_;
 };
 
-class TestReentrantWorker : public AsyncEventEmittingReentrantCWorker<16> {
+class TestReentrantWorker : public AsyncEventEmittingReentrantCWorker<16, TestReentrantWorker> {
  public:
     TestReentrantWorker(Nan::Callback* callback, std::shared_ptr<EventEmitter> emitter, size_t n)
         : AsyncEventEmittingReentrantCWorker(callback, emitter), n_(n) {}

--- a/test/js/eventemitter.js
+++ b/test/js/eventemitter.js
@@ -1,9 +1,9 @@
 'use strict'
-
 const expect = require('code').expect
 const testRoot = require('path').resolve(__dirname, '..')
 const bindings = require('bindings')({ 'module_root': testRoot, bindings: 'eventemitter' })
 const iterate = require('leakage').iterate
+const Promise = global.Promise
 
 describe('Verify EventEmitter Single', function() {
     it('should invoke the callback for test', function(done) {
@@ -105,6 +105,32 @@ describe('Verify callback memory is reclaimed', function() {
             thing.on('test', function(ev) {
                 v.compare(new Buffer(1000))
             })
+        })
+        done()
+    })
+})
+
+describe('Verify test memory is reclaimed', function() {
+    it('Should not increase memory usage over time', function(done) {
+        this.timeout(15000)
+        iterate.async(() => { 
+            let blocker = true
+            let thing = new bindings.EmitterThing()
+            let v = new Buffer(1000)
+
+            thing.on('test', function(ev) {
+                v.compare(new Buffer(1000))
+                blocker = false
+            })
+            thing.run(1)
+
+            const blocking = Promise.resolve(() => {
+                if (blocker) {
+                    return blocking
+                }
+            })
+
+            return blocking
         })
         done()
     })


### PR DESCRIPTION
Based on jamie/callback_leak_fix. This deals with the issue that the DTOR for base-classes wasn't getting called in the AsyncClose callback. This is an API breaking update, in that it requires the CRTP from implementors to ensure they're class is destroyed properly.  