### PR TITLE
add removeAllListeners API

### DIFF
--- a/eventemitter_impl.hpp
+++ b/eventemitter_impl.hpp
@@ -85,6 +85,17 @@ class EventEmitter {
         receivers_.clear();
     }
 
+    // Return a list of all eventNames
+    virtual std::vector<std::string> eventNames() {
+        std::unique_lock<uv_rwlock> master_lock{receivers_lock_};
+        std::vector<std::string> keys;
+
+        for (auto it : receivers_) {
+            keys.emplace_back(it.first);
+        }
+        return keys;
+    }
+
     /// Emit a value to any registered callbacks for the event
     ///
     /// @param[in] ev - event name

--- a/eventemitter_impl.hpp
+++ b/eventemitter_impl.hpp
@@ -67,6 +67,24 @@ class EventEmitter {
         it->second->emplace_back(cb);
     }
 
+    /// Remove all listeners for a given event
+    ///
+    /// @param[in] ev - event name
+    virtual void removeAllListenersForEvent(const std::string& ev) {
+        std::unique_lock<uv_rwlock> master_lock{receivers_lock_};
+        auto it = receivers_.find(ev);
+
+        if (it != receivers_.end()) {
+            receivers_.erase(it);
+        }
+    }
+
+    /// Remove all listeners for all events
+    virtual void removeAllListeners() {
+        std::unique_lock<uv_rwlock> master_lock{receivers_lock_};
+        receivers_.clear();
+    }
+
     /// Emit a value to any registered callbacks for the event
     ///
     /// @param[in] ev - event name

--- a/test/js/eventemitter.js
+++ b/test/js/eventemitter.js
@@ -21,6 +21,20 @@ describe('Verify EventEmitter', function() {
 
             thing.run(n)
         })
+
+        it('should remove listeners for the test event', function(done) {
+            let thing = new bindings.EmitterThing()
+            thing.on('test1', function(ev) { })
+            thing.on('test2', function(ev) { })
+
+            expect(thing.eventNames()).to.be.equal(['test2', 'test1'])
+            thing.removeAllListeners('test1')
+            expect(thing.eventNames()).to.be.equal(['test2'])
+            thing.on('test1', function(ev) { })
+            thing.removeAllListeners()
+            expect(thing.eventNames()).to.be.equal([])
+            done()
+        })
     })
 
     describe('Verify EventEmitter Multi', function() {

--- a/test/js/eventemitter.js
+++ b/test/js/eventemitter.js
@@ -22,7 +22,7 @@ describe('Verify EventEmitter', function() {
             thing.run(n)
         })
 
-        it('should remove listeners for the test event', function(done) {
+        it('should remove listeners for a specific test event', function(done) {
             let thing = new bindings.EmitterThing()
             thing.on('test1', function(ev) { })
             thing.on('test2', function(ev) { })
@@ -30,7 +30,14 @@ describe('Verify EventEmitter', function() {
             expect(thing.eventNames()).to.be.equal(['test2', 'test1'])
             thing.removeAllListeners('test1')
             expect(thing.eventNames()).to.be.equal(['test2'])
+            done()
+        })
+
+        it('should remove all listeners for all events', function(done) {
+            let thing = new bindings.EmitterThing()
             thing.on('test1', function(ev) { })
+            thing.on('test2', function(ev) { })
+
             thing.removeAllListeners()
             expect(thing.eventNames()).to.be.equal([])
             done()


### PR DESCRIPTION
This adds some additional methods to get slightly closer to the API described in https://nodejs.org/api/events.html 

Specifically, this introduces:
- https://nodejs.org/api/events.html#events_emitter_eventnames
- https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname